### PR TITLE
Use verbose and warn in development mode to expose elm compiler errors to the developer

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ if ( TARGET_ENV === 'development' ) {
         {
           test:    /\.elm$/,
           exclude: [/elm-stuff/, /node_modules/],
-          loader:  'elm-webpack'
+          loader:  'elm-webpack?verbose=true&warn=true'
         },
         {
           test: /\.(css|scss)$/,


### PR DESCRIPTION
In order to see the elm compiler errors in the terminal when developing, use the verbose and warn options on the elm-webpack loader.

Before:

![screen shot 2016-05-16 at 13 50 22](https://cloud.githubusercontent.com/assets/657839/15288774/a5df5140-1b6d-11e6-9e8c-295f3d895f7f.png)

After:

![screen shot 2016-05-16 at 13 50 47](https://cloud.githubusercontent.com/assets/657839/15288775/a5fa360e-1b6d-11e6-8178-fe38b2e32f3d.png)

---

I think this would make a great addition to this boilerplate repo.

Thanks a lot for maintaining it ❤️ 
