### PR TITLE
Bump elm-webpack-loader + webpack + webpack-merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "css-loader": "0.23.1",
     "elm": "0.17.0",
     "elm-hot-loader": "0.3.2",
-    "elm-webpack-loader": "3.0.1",
+    "elm-webpack-loader": "^3.0.3",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
     "html-webpack-plugin": "2.17.0",
@@ -29,8 +29,8 @@
     "sass-loader": "3.2.0",
     "style-loader": "0.13.1",
     "url-loader": "^0.5.7",
-    "webpack": "1.13.0",
+    "webpack": "^1.13.1",
     "webpack-dev-server": "1.14.1",
-    "webpack-merge": "0.12.0"
+    "webpack-merge": "^0.13.0"
   }
 }


### PR DESCRIPTION
`elm-webpack-loaded` 3.0.1 has a bug which causes the compilation to stopco mpletely when there was a single compilation error. 3.0.3 fixes that. For more information please check: https://github.com/rtfeldman/elm-webpack-loader/issues/53

This fixes #20.
