### PR TITLE
Rename model to initialModel to avoid variable shadowing

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -10,14 +10,14 @@ import Components.Hello exposing ( hello )
 -- APP
 main : Program Never
 main =
-  Html.beginnerProgram { model = model, view = view, update = update }
+  Html.beginnerProgram { model = initialModel, view = view, update = update }
 
 
 -- MODEL
 type alias Model = Int
 
-model : number
-model = 0
+initialModel : number
+initialModel = 0
 
 
 -- UPDATE


### PR DESCRIPTION
This renames `model` to `initialModel` to avoid variable shadowing.

I ran into an issue where I was refactoring views by extracting components and the program was compiling but not exhibiting correct behavior due to `model` still being available (in its base state).