### PR TITLE
Update README.md to 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ npm run build
 
 ### Changelog
 
+**Ver 0.8.0**
+* Updated to Elm 0.18. Using `debug=true` on webpack loader.
+
 **Ver 0.7.1**
 * Fix favicon issues, per [Issue 30](https://github.com/moarwick/elm-webpack-starter/issues/30)
 


### PR DESCRIPTION
@moarwick thanks for accepting my previous commit.

I forgot to update the README and I think it is a good idea to make a new release (`0.8.0`) in this case because of versions changes, to make clear that is compatible with `0.18`