### PR TITLE
Fix for issue#43 (webpack-dev-server now works on Windows)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/moarwick/elm-webpack-starter"
   },
   "scripts": {
-    "start": "webpack-dev-server --hot --inline --content-base src/",
+    "start": "webpack-dev-server --hot --inline",
     "build": "rimraf dist && webpack && mv dist/*.eot dist/static/css/ && mv dist/*.woff* dist/static/css/ && mv dist/*.svg dist/static/css/ && mv dist/*.ttf dist/static/css/",
     "reinstall": "npm i rimraf && rimraf node_modules && npm uninstall -g elm && npm i -g elm && npm i && elm package install"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ var commonConfig = {
 
   output: {
     path:       outputPath,
-    filename:   path.join( 'static/js/', outputFilename ),
+    filename: `static/js/${outputFilename}`,
     // publicPath: '/'
   },
 
@@ -63,6 +63,7 @@ if ( TARGET_ENV === 'development' ) {
     devServer: {
       // serve index.html in place of 404 responses
       historyApiFallback: true,
+      contentBase: './src',
     },
 
     module: {


### PR DESCRIPTION
The file name of the bundle produced is not found on a Windows machine by the webpack-dev-server. This fixes that issue.

The `--content-base` flag was also relocated to the `webpack.config.js` file so all config is in one spot.