### PR TITLE
Replace `reinstall` script with a simpler `postinstall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ git add .
 git commit -m 'first commit'
 ```
 
-Install all dependencies using the handy `reinstall` script:
+Install all npm and elm dependencies:
 ```
-npm run reinstall
+npm install
 ```
-*This does a clean (re)install of all npm and elm packages, plus a global elm install.*
 
 
 ### Serve locally:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "webpack-dev-server --hot --inline",
     "build": "rimraf dist && webpack && mv dist/*.eot dist/static/css/ && mv dist/*.woff* dist/static/css/ && mv dist/*.svg dist/static/css/ && mv dist/*.ttf dist/static/css/",
-    "reinstall": "npm i rimraf && rimraf node_modules && npm uninstall -g elm && npm i -g elm && npm i && elm package install"
+    "postinstall": "elm package install -y"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.6",


### PR DESCRIPTION
Hi there,

first of all, thanks for a great starter pack 👍 Hopefully I'm not stepping on any toes here, just want to suggest some changes after prior experiences over the years.

These changes are suggested for a couple of reasons:

**Ideally running `npm install`**

`npm install` is the de-facto way of installing dependencies in npm projects.

The built-in install script has [lifecycle scripts](https://docs.npmjs.com/misc/scripts) that allows us to perform actions *after* all npm dependencies has been installed for the project.

npm ensures that dependencies installed which includes executable files are available in `$PATH` when npm scripts are run. In practise that means a custom `build` npm script might use `elm` as if it were globally installed on the machine, but it infact is a `devDependency` to that particular project.

**Avoiding global dependencies**

Ideally a project does not require global packages installed on the machine to run. This is cause of two reasons basically:

- There is no good way to specify a system wide `dependency` and its version
- A developer might want to run different versions of e.g. `elm` on different projects. By enforcing global installs, that's quite painful.

Any thoughts? Are there reasons the previous `reinstall` existed that I'm overlooking?