### PR TITLE
Change type annotations for easier start for beginners

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -8,7 +8,7 @@ import Components.Hello exposing ( hello )
 
 
 -- APP
-main : Program Never Int Msg
+main : Program Never Model Msg
 main =
   Html.beginnerProgram { model = model, view = view, update = update }
 
@@ -16,7 +16,7 @@ main =
 -- MODEL
 type alias Model = Int
 
-model : number
+model : Model
 model = 0
 
 


### PR DESCRIPTION
Hello!

It seems that current type annotations may cause an error which beginners do not expect.

Let's say you want to change model to a `{counter: 0}`. Even if you correctly change `model`, `update` and `view` functions, you would get an unexpected error with a code you didn't change:

```
ERROR in ./src/elm/Main.elm
Module build failed: Error: Compiler process exited with error Compilation failed
-- TYPE MISMATCH

The definition of `main` does not match its type annotation.

 8| main : Program Never Int Msg
 9| main =
10|>  Html.beginnerProgram { model = model, view = view, update = update }

The type annotation for `main` says it is a:

    Program Never Int Msg

But the definition (shown above) is a:

    Program Never Model Msg
```
