### PR TITLE
Set webpack publicPath to allow for nested url paths

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ var commonConfig = {
     output: {
         path: outputPath,
         filename: `static/js/${outputFilename}`,
+        publicPath: '/',
     },
     resolve: {
         extensions: ['.js', '.elm'],


### PR DESCRIPTION
Without explicitly setting `publicPath`, webpack builds the output path for `main.js` relative to the URL. This works fine for paths such as `/` and `/posts`, but as soon as the path is nested at least once the request for `main.js` 404s.