### PR TITLE
To also minimize the css file in dist folder.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "webpack-dev-server --hot --inline",
     "prebuild": "rimraf dist",
-    "build": "webpack",
+    "build": "webpack -p",
     "reinstall": "npm i rimraf && rimraf node_modules && npm uninstall -g elm && npm i -g elm && npm i && elm package install"
   },
   "devDependencies": {


### PR DESCRIPTION
Too many lines of code being pushed in a webapp repo because of the css file in `dist` folder. `dist` folder in github repo is for free gh-pages hosting.